### PR TITLE
Added GitHub Actions build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,22 @@ name: Continuous Integration
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: Build
+  tests:
     runs-on: ubuntu-latest
+    name: Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+        - "3.2"
+        - "3.1"
+        - "3.0"
+        include:
+          - ruby: "3.2"
+            coverage: "true"
+    env:
+      COVERAGE: ${{matrix.coverage}}
+      COVERAGE_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
 
     steps:
       - name: Checkout
@@ -14,6 +27,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ${{matrix.ruby}}
           bundler-cache: true
 
       - name: Rake
@@ -24,4 +38,3 @@ jobs:
         with:
           name: coverage
           path: coverage
-

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-ruby File.read(".ruby-version").strip
-
 source "https://rubygems.org"
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ source "https://rubygems.org"
 gemspec
 
 group :code_quality do
-  gem "git-lint", "~> 6.0"
   gem "reek", "~> 6.1", require: false
   gem "rubocop", "~> 1.56"
   gem "simplecov", "~> 0.22", require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "git/lint/rake/register"
 require "reek/rake/task"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
 
-Git::Lint::Rake::Register.call
 Reek::Rake::Task.new
 RSpec::Core::RakeTask.new { |task| task.verbose = false }
 RuboCop::RakeTask.new
 
 desc "Run code quality checks"
-task code_quality: %i[git_lint reek rubocop]
+task code_quality: %i[reek rubocop]
 
 task default: %i[code_quality spec]


### PR DESCRIPTION
## Overview

Necessary to build on the team's supported Ruby versions.

## Details

- Resolves Issue #2.
- Git Lint was removed since I don't support older versions of Ruby in order to keep my health and sanity in check. 😅 This could be still used as a separate action but doesn't sound like this will be welcome in the community.