### PR TITLE
Added inspectable Zeitwerk loader

### DIFF
--- a/lib/dry/operation.rb
+++ b/lib/dry/operation.rb
@@ -2,13 +2,18 @@
 
 require "zeitwerk"
 
-Zeitwerk::Loader.new.then do |loader|
-  loader.push_dir "#{__dir__}/.."
-  loader.setup
-end
-
 module Dry
   # Main namespace.
   module Operation
+    def self.loader
+      @loader ||= Zeitwerk::Loader.new.tap do |loader|
+        root = File.expand_path "..", __dir__
+        loader.inflector = Zeitwerk::GemInflector.new("#{root}/dry/operation.rb")
+        loader.tag = "dry-operation"
+        loader.push_dir root
+      end
+    end
+
+    loader.setup
   end
 end


### PR DESCRIPTION
## Overview

Necessary to not only load the full implementation of this gem but also provide a way in which to inspect this gem's loader. For quick inspection, launch the console (i.e. `bin/console`) and use `Dry::Operation.loader`.

## Screenshots/Screencasts

![2023-09-30_09-44-05-iTerm2](https://github.com/dry-rb/dry-operation/assets/50245/77eff260-39ab-40d2-920f-99c050e49fde)

## Details

Resolved Issue #3 