### PR TITLE
Avoid `#steps` boilerplate by prepending on `#call`

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--markup markdown

--- a/lib/dry/operation.rb
+++ b/lib/dry/operation.rb
@@ -9,51 +9,86 @@ module Dry
   # {Dry::Operation} is a thin DSL wrapping dry-monads that allows you to chain
   # operations by focusing on the happy path and short-circuiting on failure.
   #
-  # The entry-point for defining your operations flow is {#steps}. It accepts a
-  # block where you can call individual operations through {#step}. Operations
-  # need to return either a success or a failure result. Successful results will
-  # be automatically unwrapped, while a failure will stop further execution of
-  # the block.
+  # The canonical way of using it is to subclass {Dry::Operation} and define
+  # your flow in the `#call` method. Individual operations can be called with
+  # {#step}. They need to return either a success or a failure result.
+  # Successful results will be automatically unwrapped, while a failure will
+  # stop further execution of the method.
   #
-  # @example
-  #  class MyOperation < Dry::Operation
-  #    def call(input)
-  #      steps do
-  #        attrs = step validate(input)
-  #        user = step persist(attrs)
-  #        step notify(user)
-  #        user
-  #      end
-  #    end
+  # ```ruby
+  # class MyOperation < Dry::Operation
+  #   def call(input)
+  #     attrs = step validate(input)
+  #     user = step persist(attrs)
+  #     step notify(user)
+  #     user
+  #   end
   #
-  #    def validate(input)
-  #     # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
-  #    end
+  #   def validate(input)
+  #    # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
+  #   end
   #
-  #    def persist(attrs)
-  #     # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
-  #    end
+  #   def persist(attrs)
+  #    # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
+  #   end
   #
-  #    def notify(user)
-  #     # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
-  #    end
-  #  end
+  #   def notify(user)
+  #    # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
+  #   end
+  # end
   #
-  #  include Dry::Monads[:result]
+  # include Dry::Monads[:result]
   #
-  #  case MyOperation.new.call(input)
-  #  in Success(user)
-  #    puts "User #{user.name} created"
-  #  in Failure[:invalid_input, validation_errors]
-  #    puts "Invalid input: #{validation_errors}"
-  #  in Failure(:database_error)
-  #    puts "Database error"
-  #  in Failure(:email_error)
-  #    puts "Email error"
-  #  end
+  # case MyOperation.new.call(input)
+  # in Success(user)
+  #   puts "User #{user.name} created"
+  # in Failure[:invalid_input, validation_errors]
+  #   puts "Invalid input: #{validation_errors}"
+  # in Failure(:database_error)
+  #   puts "Database error"
+  # in Failure(:email_error)
+  #   puts "Email error"
+  # end
+  # ```
+  #
+  # Under the hood, the `#call` method is decorated to allow skipping the rest
+  # of its execution when a failure is encountered. You can choose to use another
+  # method name by inheriting from `Dry::Operation[prepend:
+  # :another_method]` or `Dry::Operation[prepend: [:method_one, :method_two]]`
+  # for multiple methods.
+  #
+  # ```ruby
+  # class MyOperation < Dry::Operation[prepend: :run]
+  #   def run(input)
+  #     attrs = step validate(input)
+  #     user = step persist(attrs)
+  #     step notify(user)
+  #     user
+  #   end
+  #
+  #   # ...
+  # end
+  # ```
+  #
+  # You can opt out altogether of this behavior by inheriting from
+  # `Dry::Operation[prepend: false]`. If so, you manually need to wrap your flow
+  # within the {#steps} method.
+  #
+  # ```ruby
+  # class MyOperation < Dry::Operation[prepend: false]
+  #   def call(input)
+  #     steps do
+  #       attrs = step validate(input)
+  #       user = step persist(attrs)
+  #       step notify(user)
+  #       user
+  #     end
+  #   end
+  #
+  #   # ...
+  # end
+  # ```
   class Operation
-    include Dry::Monads::Result::Mixin
-
     def self.loader
       @loader ||= Zeitwerk::Loader.new.tap do |loader|
         root = File.expand_path "..", __dir__
@@ -64,24 +99,22 @@ module Dry
     end
     loader.setup
 
-    # Wraps block's return value in a {Success}
-    #
-    # Catches :halt and returns it
-    #
-    # @yieldreturn [Object]
-    # @return [Dry::Monads::Result::Success]
-    # @see #step
-    def steps(&block)
-      catch(:halt) { Success(block.call) }
+    # @param prepend [Symbol, Array<Symbol>, false] method(s) to wrap as the
+    #   block in {#steps}. `false` for none.
+    # @return [Class]
+    def self.[](prepend:)
+      enable(klass: Class.new, prepend: prepend)
     end
 
-    # Unwrapps a {Success} or throws :halt with a {Failure}
-    #
-    # @param result [Dry::Monads::Result]
-    # @return [Object] wrapped value
-    # @see #steps
-    def step(result)
-      result.value_or { throw :halt, result }
+    # @api private
+    def self.enable(klass:, prepend:)
+      klass.tap do
+        klass.include(Mixin)
+        Prepender.inherited_hook(klass: klass, methods: Array(prepend))
+      end
     end
+
+    # @!parse include Mixin
+    enable(klass: self, prepend: :call)
   end
 end

--- a/lib/dry/operation/mixin.rb
+++ b/lib/dry/operation/mixin.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Dry
+  class Operation
+    module Mixin
+      include Dry::Monads::Result::Mixin
+
+      # Wraps block's return value in a {Dry::Monads::Result::Success}
+      #
+      # Catches :halt and returns it
+      #
+      # @yieldreturn [Object]
+      # @return [Dry::Monads::Result::Success]
+      # @see #step
+      def steps(&block)
+        catch(:halt) { Success(block.call) }
+      end
+
+      # Unwrapps a {Dry::Monads::Result::Success}
+      #
+      # Throws :halt with a {Dry::Monads::Result::Failure} on failure.
+      #
+      # @param result [Dry::Monads::Result]
+      # @return [Object] wrapped value
+      # @see #steps
+      def step(result)
+        result.value_or { throw :halt, result }
+      end
+    end
+  end
+end

--- a/lib/dry/operation/prepender.rb
+++ b/lib/dry/operation/prepender.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Dry
+  class Operation
+    # @api private
+    class Prepender < Module
+      def self.inherited_hook(klass:, methods:)
+        return unless methods.any?
+
+        klass.define_singleton_method(:inherited) do |subklass|
+          super(subklass)
+          subklass.include(Prepender.new(methods: methods))
+        end
+      end
+
+      def initialize(methods:)
+        super()
+        @methods = methods
+      end
+
+      def included(klass)
+        klass.prepend(mod)
+      end
+
+      private
+
+      def mod
+        @module ||= Module.new.tap do |mod|
+          @methods.each do |method|
+            mod.define_method(method) do |*args, **kwargs, &block|
+              steps do
+                super(*args, **kwargs, &block)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/operations_spec.rb
+++ b/spec/integration/operations_spec.rb
@@ -40,4 +40,94 @@ RSpec.describe "Operations" do
       klass.new.divide_by_zero_then_add_one(1)
     ).to eq(Failure(:not_possible))
   end
+
+  it "prepends #steps around #call on inherited classes" do
+    klass = Class.new(Dry::Operation) do
+      def call(x)
+        step add_one(x)
+      end
+
+      def add_one(x) = Success(x + 1)
+    end
+
+    expect(
+      klass.new.(1)
+    ).to eq(Success(2))
+  end
+
+  it "keeps prepending down the inheritance tree" do
+    klass = Class.new(Dry::Operation)
+    qlass = Class.new(klass) do
+      def call(x)
+        step add_one(x)
+      end
+
+      def add_one(x) = Success(x + 1)
+    end
+
+    expect(
+      qlass.new.(1)
+    ).to eq(Success(2))
+  end
+
+  it "can prepend around a method other than #call with the prepend: option" do
+    klass = Class.new(Dry::Operation[prepend: :run]) do
+      def run(x)
+        step add_one(x)
+      end
+
+      def add_one(x) = Success(x + 1)
+    end
+
+    expect(
+      klass.new.run(1)
+    ).to eq(Success(2))
+  end
+
+  it "keeps prepending down the inheritance tree when prepending around a custom method" do
+    klass = Class.new(Dry::Operation[prepend: :run])
+    qlass = Class.new(klass) do
+      def run(x)
+        step add_one(x)
+      end
+
+      def add_one(x) = Success(x + 1)
+    end
+
+    expect(
+      qlass.new.run(1)
+    ).to eq(Success(2))
+  end
+
+  it "can prepend around several methods by passing an array as the prepend: option" do
+    klass = Class.new(Dry::Operation[prepend: %i[call run]]) do
+      def call(x)
+        step add_one(x)
+      end
+
+      def run(x)
+        step add_one(x)
+      end
+
+      def add_one(x) = Success(x + 1)
+    end
+
+    expect(
+      [klass.new.(1), klass.new.run(1)]
+    ).to eq([Success(2), Success(2)])
+  end
+
+  it "can avoid prepending any method by passing false as the prepend: option" do
+    klass = Class.new(Dry::Operation[prepend: false]) do
+      def run(x)
+        step add_one(x)
+      end
+
+      def add_one(x) = Success(x + 1)
+    end
+
+    expect(
+      klass.new.run(1)
+    ).to eq(2)
+  end
 end


### PR DESCRIPTION
We get rid of the necessity to wrap the operations' flow with the `#steps`'s block by prepending a module that decorates the `#call` method.

If before we had to do:

```ruby
class CreateUser < Dry::Operation
  def call(input)
    steps do
      attributes = step validate(input)
      step create(attributes)
    end
  end

  # ...
end
```

Now we can do:

```ruby
class CreateUser < Dry::Operation
  def call(input)
    attributes = step validate(input)
    step create(attributes)
  end

  # ...
end
```

We want to provide that as the default behavior to improve the ergonomics of the library. However, we also want to provide a way to customize or opt out of this magic behavior. Users can inherit from, e.g., `Dry::Operation[prepend: :run]` to decorate the `#run` method (multiple methods are allowed by passing an array), or `Dry::Operation[prepend: false]` to disable the behavior:

```ruby
class CreateUser < Dry::Operation[prepend: :run]
  def run(input)
    attributes = step validate(input)
    step create(attributes)
  end

  # ...
end
```

```ruby
class CreateUser < Dry::Operation[prepend: :false]
  def call(input)
    steps do
      attributes = step validate(input)
      step create(attributes)
    end
  end

  # ...
end
```

Notice that as a consequence of this change, we're "polluting" the ancestry chain of the descendant classes with the prepender logic:

```ruby
Class.new(Dry::Operation).ancestors
# [#<Module:0x00007f8e523c1698>, <- Actual prepender
#  #<Class:0x00007f8e523c1918>, <- Descendant
#  #<Dry::Operation::Prepender:0x00007f8e523c17d8>, <- Stateful module keeping the prepender options
#  Dry::Operation,
#  Dry::Operation::Mixin,
# ...]
```

When creating a descendant from a descendant, the prepender logic is duplicated to override the decorated method from the nested descendant (which goes before the first prepender in the ancestry):

```ruby
Class.new(Class.new(Dry::Operation)).ancestors
# [#<Module:0x00007f8e52331408>, <- Actual prepender
#  #<Class:0x00007f8e52331688>, <- Nested descendant
#  #<Dry::Operation::Prepender:0x00007f8e52331548>, <- Stateful module keeping the prepender options
#  #<Module:0x00007f8e52331868>, <- Previous prepender
#  #<Class:0x00007f8e52331ae8>, <- Descendant
#  #<Dry::Operation::Prepender:0x00007f8e523319a8>, <- Previous stateful module keeping the prepender options
#  Dry::Operation,
#  Dry::Operation::Mixin,
#  ...]
```

Also, notice that `Dry::Operation[]` will return an anonymous `Class` so it can be inherited from, so `Dry::Operation` won't appear in the ancestry chain:

```ruby
Class.new(Dry::Operation[prepend: false]).ancestors
# [#<Class:0x00007f8e5233eec8>, <- Descendant
#  #<Class:0x00007f8e5233f328>, <- Anonymous class returned by Dry::Operation[]
#  Dry::Operation::Mixin,
#  ...]
```

To accomodate the above, the steps logic has been moved to a `Dry::Operation::Mixin` module so it can be reused both by descendants from `Dry::Operation` and `Dry::Operation[]`.

It's worth it to highlight all that complexity, although it should be transparent to the user. As said, it's a trade-off we consider worth it to improve developer experience.