### PR TITLE
Basic class to define routine context and to mount it into fiber

### DIFF
--- a/lib/dry/operation.rb
+++ b/lib/dry/operation.rb
@@ -63,6 +63,7 @@ module Dry
       end
     end
     loader.setup
+    loader.eager_load_dir("#{__dir__}/operation/plugins")
 
     # Wraps block's return value in a {Success}
     #

--- a/lib/dry/operation/plugins/routine.rb
+++ b/lib/dry/operation/plugins/routine.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Dry
+  class Operation
+    module Plugins
+      module Routine
+        # Refers to routine in current fiber
+        #
+        # @return [Routine]
+        # @api public
+        def routine
+          Fiber[:__routine__]
+        end
+      end
+
+      if defined?(Dry::System::Plugin)
+        Dry::System::Plugin.register(:routine, Routine)
+      end
+    end
+  end
+end

--- a/lib/dry/operation/routine.rb
+++ b/lib/dry/operation/routine.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Dry
+  class Operation
+    # Wrapper for complex multi-component operations.
+    # It wraps the target operation in fiber and
+    # puts self-instance to fiber storage to use the instance as context object
+    # providing temporary data and settings for operation participants.
+    #
+    # @example
+    #  class MyMultiOperation < Dry::Operation
+    #    def call(input)
+    #      steps do
+    #        info = step composer.call(input)
+    #        result = step reporter.call(info)
+    #        result
+    #      end
+    #    end
+    #  end
+    #
+    #  class Composer
+    #    def call(input)
+    #     # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
+    #    end
+    #
+    #    def current_vendor
+    #      routine.vendor
+    #    end
+    #  end
+    #
+    #  class Reporter
+    #    def call(info)
+    #     # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
+    #    end
+    #
+    #    def current_vendor
+    #      routine.vendor
+    #    end
+    #  end
+    #
+    #  class Routine < Dry::Operation::Routine
+    #    attr_reader :vendor
+    #
+    #    def initialize(vendor)
+    #      @vendor = vendor
+    #    end
+    #
+    #    def callee
+    #      MyMultiOperation.new
+    #    end
+    #  end
+    #
+    class Routine
+      # Launches routine in fiber
+      #
+      # @return [Object]
+      # @api public
+      def resume(*args)
+        fiber.resume(*args)
+      end
+
+      # Prepares routine fiber (without starting)
+      #
+      # @return [Fiber]
+      # @api public
+      def fiber
+        @fiber ||= Fiber.new(fiber_options, &self)
+      end
+
+      # Sends routine to fiber scheduler.
+      # Expects fiber scheduler settings.
+      #
+      # @return [Fiber]
+      # @api public
+      def schedule(*args)
+        Fiber.schedule(*args, &self)
+      end
+
+      # to override
+      #
+      # @return [Proc]
+      # @api public
+      def callee
+        proc {}
+      end
+
+      # to override
+      # Provides settings to initialize a fiber
+      #
+      # @return [Hash]
+      # @api public
+      def fiber_options
+        {}
+      end
+
+      # @api private
+      def to_proc
+        proc do |*args|
+          Fiber[:__routine__] = self
+          callee.call(*args)
+        end
+      end
+    end
+
+    loader.eager_load_dir("#{__dir__}/routine")
+  end
+end

--- a/lib/dry/operation/routine/storage_methods.rb
+++ b/lib/dry/operation/routine/storage_methods.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Dry
+  class Operation
+    class Routine
+      # Simple implementation of fiber storage
+      #
+      # Replacement until fiber native storage appears (until the ruby version 3.3.0)
+      # https://docs.ruby-lang.org/en/master/Fiber.html#method-i-storage
+      module StorageMethods
+        module InstanceMethods
+          def __storage__
+            @__storage__ ||= {}
+          end
+        end
+
+        module ClassMethods
+          def [](name)
+            current.__storage__[name]
+          end
+
+          def []=(name, obj)
+            current.__storage__[name] = obj
+          end
+        end
+
+        if  Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.3.0") ||
+            ENV["FORCE_DRY_OPERATION_ROUTINE_STORAGE"] == "true"
+          Fiber.class_eval do
+            extend ClassMethods
+            prepend InstanceMethods
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/routine_spec.rb
+++ b/spec/integration/routine_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Routines" do
+  include Dry::Monads[:result]
+
+  it "mounts routine and launches operation based on routine content" do
+    sum_klass = Class.new do
+      include Dry::Operation::Plugins::Routine
+      include Dry::Monads[:result]
+
+      define_method :call do
+        Success(routine.elements.sum)
+      end
+    end
+
+    counter_klass = Class.new do
+      include Dry::Operation::Plugins::Routine
+      include Dry::Monads[:result]
+
+      define_method :call do
+        Success(routine.elements.size)
+      end
+    end
+
+    operation_klass = Class.new(Dry::Operation) do
+      include Dry::Monads[:result]
+
+      define_method :call do
+        steps do
+          v = step sum_calculator.call
+          n = step counter.call
+          step avg(v, n)
+        end
+      end
+
+      define_method(:sum_calculator) { sum_klass.new }
+      define_method(:counter) { counter_klass.new }
+      define_method :avg do |v, n|
+        Success(v.to_f / n)
+      end
+    end
+
+    routine_klass = Class.new(Dry::Operation::Routine) do
+      attr_reader :elements
+
+      define_method :initialize do |elements|
+        @elements = elements
+      end
+
+      define_method :callee do
+        operation_klass.new
+      end
+    end
+
+    expect(routine_klass.new(1..25).resume).to eq(Success(13))
+  end
+end

--- a/spec/unit/routine_spec.rb
+++ b/spec/unit/routine_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Dry::Operation::Routine do
+  describe "#resume" do
+    it "calls callee" do
+      klass = Class.new(Dry::Operation::Routine) do
+        def callee
+          proc { |n| n + 1 }
+        end
+      end
+
+      routine = klass.new
+      expect(routine.resume(2)).to eq(3)
+    end
+  end
+
+  describe "#fiber" do
+    it "creates fiber with routine context in fiber storage" do
+      callee_klass = Class.new do
+        def call(n)
+          n + Fiber[:__routine__].num
+        end
+      end
+
+      klass = Class.new(Dry::Operation::Routine) do
+        def num
+          8
+        end
+
+        define_method :callee do
+          callee_klass.new
+        end
+      end
+
+      fiber = klass.new.fiber
+      expect(fiber).to be_a(Fiber)
+      expect(fiber.resume(1)).to eq(9)
+    end
+  end
+
+  describe "#schedule" do
+    it "creates fiber and starts it" do
+      scheduler_klass = Class.new do
+        attr_reader :kernel_sleep, :io_wait, :block, :unblock
+
+        def fiber(*args, &block)
+          fiber = Fiber.new(&block)
+          fiber.resume(*args)
+          fiber
+        end
+      end
+
+      result = Struct.new(:val).new
+
+      klass = Class.new(Dry::Operation::Routine) do
+        define_method :callee do
+          proc { |n| result.val = n + 5 }
+        end
+      end
+
+      begin
+        Fiber.set_scheduler(scheduler_klass.new)
+        expect(klass.new.schedule(5)).to be_a(Fiber)
+        expect(result.val).to eq(10)
+      ensure
+        Fiber.set_scheduler(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Overview

Routine context feature based on [fiber storage](https://docs.ruby-lang.org/en/master/Fiber.html#method-i-storage).

Useful to have this tool when we develop a project with number of vendors or customers with their own scope of settings and data scopes and we need to implement complex multi-component operations including several classes related to vendor properties.

## Details

Simple draft example:

```
class MyMultiOperation < Dry::Operation
  def call(input)
    steps do
      info = step composer.call(input)
      result = step reporter.call(info)
      result
    end
  end
end

class Composer
  def call(input)
   # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
  end

  def current_vendor
    routine.vendor
  end
end

class Reporter
  def call(info)
   # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
  end

  def current_vendor
    routine.vendor
  end
end

class Routine < Dry::Operation::Routine
  attr_reader :vendor

  def initialize(vendor)
    @vendor = vendor
  end

  def callee
    MyMultiOperation.new
  end
end
```