### PR TITLE
Call a global #on_failure hook when the flow fails

### DIFF
--- a/lib/dry/operation/class_context/steps_method_prepender.rb
+++ b/lib/dry/operation/class_context/steps_method_prepender.rb
@@ -1,13 +1,35 @@
 # frozen_string_literal: true
 
+require "dry/operation/errors"
+
 module Dry
   class Operation
     module ClassContext
       # @api private
       class StepsMethodPrepender < Module
-        def initialize(method:)
+        FAILURE_HOOK_METHOD_NAME = :on_failure
+
+        RESULT_HANDLER = lambda do |instance, method, result|
+          return if result.success? ||
+                    !(instance.methods + instance.private_methods).include?(
+                      FAILURE_HOOK_METHOD_NAME
+                    )
+
+          failure_hook = instance.method(FAILURE_HOOK_METHOD_NAME)
+          case failure_hook.arity
+          when 1
+            failure_hook.(result.failure)
+          when 2
+            failure_hook.(result.failure, method)
+          else
+            raise FailureHookArityError.new(hook: failure_hook)
+          end
+        end
+
+        def initialize(method:, result_handler: RESULT_HANDLER)
           super()
           @method = method
+          @result_handler = result_handler
         end
 
         def included(klass)
@@ -18,9 +40,13 @@ module Dry
 
         def mod
           @module ||= Module.new.tap do |mod|
-            mod.define_method(@method) do |*args, **kwargs, &block|
-              steps do
-                super(*args, **kwargs, &block)
+            module_exec(@result_handler) do |result_handler|
+              mod.define_method(@method) do |*args, **kwargs, &block|
+                steps do
+                  super(*args, **kwargs, &block)
+                end.tap do |result|
+                  result_handler.(self, __method__, result)
+                end
               end
             end
           end

--- a/lib/dry/operation/errors.rb
+++ b/lib/dry/operation/errors.rb
@@ -35,5 +35,15 @@ module Dry
 
     # An error related to an extension
     class ExtensionError < ::StandardError; end
+
+    # Defined failure hook has wrong arity
+    class FailureHookArityError < ::StandardError
+      def initialize(hook:)
+        super <<~MSG
+          ##{hook.name} must accept 1 (failure) or 2 (failure, method name) \
+          arguments, but its arity is #{hook.arity}
+        MSG
+      end
+    end
   end
 end


### PR DESCRIPTION
Most of the time, individual operations are responsible for handling their own failures. However, there are cases when it makes sense to handle failures globally, for example, when you want to log the error for a given flow.

When using the raw behavior, i.e., when we don't prepend around methods, that can be easily handled manually:

```ruby
class CreateUser < Dry::Operation
  skip_prepending

  def call(input)
    steps do
      attrs = step validate(input)
      step persist(attrs)
      user
    end.tap do |result|
      log_failure(result.failure) if result.failure?
    end
  end

  # ...
end
```

However, by automatically wrapping around `#steps` we gain focus on the happy path, but we lose the ability to handle global failures.

Because of that, we introduce an `#on_failure` hook that is only called when using the prepended behavior on a failing flow. The method accepts the unwrapped failure extracted from the result object.

```ruby
class CreateUser < Dry::Operation
  def call(input)
    attrs = step validate(input)
    step persist(attrs)
    user
  end

  private

  def on_failure(failure)
    log_failure(failure)
  end

  # ...
end
```

`#on_failure` can also take a second optional argument, which will be assigned to the prepended method's name. That's useful when we're defining more than one flow in a single class.

```ruby
class UserFlows < Dry::Operation
  operate_on :create_user, :delete_user

  # ...

  private

  def on_failure(failure, flow_name)
    case flow_name
    when :create_user
      # ...
    when :delete_user
      # ...
    end
  end

  # ...
end
```

The calling of the hook is done via an injected result handler lambda. At some point, we might want to make this behavior configurable.
