### PR TITLE
Add helpful error message when not returning a Dry::Monads::Result from step

### DIFF
--- a/lib/dry/operation.rb
+++ b/lib/dry/operation.rb
@@ -2,6 +2,7 @@
 
 require "zeitwerk"
 require "dry/monads"
+require "dry/operation/errors"
 
 module Dry
   # DSL for chaining operations that can fail
@@ -136,7 +137,11 @@ module Dry
     # @return [Object] wrapped value
     # @see #steps
     def step(result)
-      result.value_or { throw_failure(result) }
+      if result.is_a?(Dry::Monads::Result)
+        result.value_or { throw_failure(result) }
+      else
+        raise InvalidStepResultError.new(result: result)
+      end
     end
 
     # Invokes a callable in case of block's failure

--- a/lib/dry/operation/errors.rb
+++ b/lib/dry/operation/errors.rb
@@ -2,8 +2,10 @@
 
 module Dry
   class Operation
+    class Error < ::StandardError; end
+
     # Methods to prepend have already been defined
-    class MethodsToPrependAlreadyDefinedError < ::StandardError
+    class MethodsToPrependAlreadyDefinedError < Error
       def initialize(methods:)
         super <<~MSG
           '.operate_on' must be called before the given methods are defined.
@@ -13,7 +15,7 @@ module Dry
     end
 
     # Configuring prepending after a method has already been prepended
-    class PrependConfigurationError < ::StandardError
+    class PrependConfigurationError < Error
       def initialize(methods:)
         super <<~MSG
           '.operate_on' and '.skip_prepending' can't be called after any methods\
@@ -24,11 +26,20 @@ module Dry
     end
 
     # Missing dependency required by an extension
-    class MissingDependencyError < ::StandardError
+    class MissingDependencyError < Error
       def initialize(gem:, extension:)
         super <<~MSG
           To use the #{extension} extension, you first need to install the \
           #{gem} gem. Please, add it to your Gemfile and run bundle install
+        MSG
+      end
+    end
+
+    class InvalidStepResultError < Error
+      def initialize(result:)
+        super <<~MSG
+          Your step must return `Success(..)` or `Failure(..)`, \
+          from `Dry::Monads::Result`. Instead, it was `#{result.inspect}`.
         MSG
       end
     end

--- a/spec/unit/operation_spec.rb
+++ b/spec/unit/operation_spec.rb
@@ -55,19 +55,7 @@ RSpec.describe Dry::Operation do
       }.to throw_symbol(:halt, failure)
     end
 
-    it "raises helpful error when returning `nil` to step" do
-      expect {
-        described_class.new.step(nil)
-      }.to raise_error(Dry::Operation::InvalidStepResultError)
-        .with_message(
-          <<~MSG
-            Your step must return `Success(..)` or `Failure(..)`, \
-            from `Dry::Monads::Result`. Instead, it was `nil`.
-          MSG
-        )
-    end
-
-    it "raises helpful error when returning an integer to step" do
+    it "raises helpful error when returning something that is not a Result" do
       expect {
         described_class.new.step(123)
       }.to raise_error(Dry::Operation::InvalidStepResultError)

--- a/spec/unit/operation_spec.rb
+++ b/spec/unit/operation_spec.rb
@@ -54,6 +54,30 @@ RSpec.describe Dry::Operation do
         described_class.new.step(failure)
       }.to throw_symbol(:halt, failure)
     end
+
+    it "raises helpful error when returning `nil` to step" do
+      expect {
+        described_class.new.step(nil)
+      }.to raise_error(Dry::Operation::InvalidStepResultError)
+        .with_message(
+          <<~MSG
+            Your step must return `Success(..)` or `Failure(..)`, \
+            from `Dry::Monads::Result`. Instead, it was `nil`.
+          MSG
+        )
+    end
+
+    it "raises helpful error when returning an integer to step" do
+      expect {
+        described_class.new.step(123)
+      }.to raise_error(Dry::Operation::InvalidStepResultError)
+        .with_message(
+          <<~MSG
+            Your step must return `Success(..)` or `Failure(..)`, \
+            from `Dry::Monads::Result`. Instead, it was `123`.
+          MSG
+        )
+    end
   end
 
   describe "#intercepting_failure" do


### PR DESCRIPTION

When using `dry-operation` for the first time, I had a method with an `if` statement without an `else`, so it was returning `nil` when the condtion wasn't true. This messes up the `step` method because it always needs either a `Dry::Monads::Result::Success` or a `Dry::Monads::Result::Failure` object.

The error I was seeing was:
```
NoMethodError: undefined method `value_or' for nil
```

And (I think due to how we prepend the methods in this gem) there was no error pointing to `dry-operation` at all, the only stacktrace lines were within my app.