### PR TITLE
Alias Dry::Monads::Result as Dry::Operation::Result

### DIFF
--- a/lib/dry/operation.rb
+++ b/lib/dry/operation.rb
@@ -26,19 +26,19 @@ module Dry
   #   end
   #
   #   def validate(input)
-  #    # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
+  #    # Dry::Operation::Result::Success or Dry::Operation::Result::Failure
   #   end
   #
   #   def persist(attrs)
-  #    # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
+  #    # Dry::Operation::Result::Success or Dry::Operation::Result::Failure
   #   end
   #
   #   def notify(user)
-  #    # Dry::Monads::Result::Success or Dry::Monads::Result::Failure
+  #    # Dry::Operation::Result::Success or Dry::Operation::Result::Failure
   #   end
   # end
   #
-  # include Dry::Monads[:result]
+  # include Dry::Operation::Result::Mixin
   #
   # case MyOperation.new.call(input)
   # in Success(user)
@@ -141,28 +141,31 @@ module Dry
     private_constant :FAILURE_TAG
 
     extend ClassContext
-    include Dry::Monads::Result::Mixin
 
-    # Wraps block's return value in a {Dry::Monads::Result::Success}
+    Result = Dry::Monads::Result
+    Result::Mixin = Dry::Monads::Result::Mixin
+    include Result::Mixin
+
+    # Wraps block's return value in a {Dry::Operation::Result::Success}
     #
     # Catches `:halt` and returns it
     #
     # @yieldreturn [Object]
-    # @return [Dry::Monads::Result::Success]
+    # @return [Dry::Operation::Result::Success]
     # @see #step
     def steps(&block)
       catching_failure { Success(block.call) }
     end
 
-    # Unwraps a {Dry::Monads::Result::Success}
+    # Unwraps a {Dry::Operation::Result::Success}
     #
-    # Throws `:halt` with a {Dry::Monads::Result::Failure} on failure.
+    # Throws `:halt` with a {Dry::Operation::Result::Failure} on failure.
     #
-    # @param result [Dry::Monads::Result]
+    # @param result [Dry::Operation::Result]
     # @return [Object] wrapped value
     # @see #steps
     def step(result)
-      if result.is_a?(Dry::Monads::Result)
+      if result.is_a?(Dry::Operation::Result)
         result.value_or { throw_failure(result) }
       else
         raise InvalidStepResultError.new(result: result)
@@ -171,7 +174,7 @@ module Dry
 
     # Invokes a callable in case of block's failure
     #
-    # Throws `:halt` with a {Dry::Monads::Result::Failure} on failure.
+    # Throws `:halt` with a {Dry::Operation::Result::Failure} on failure.
     #
     # This method is useful when you want to perform some side-effect when a
     # failure is encountered. It's meant to be used within the {#steps} block

--- a/lib/dry/operation.rb
+++ b/lib/dry/operation.rb
@@ -143,7 +143,6 @@ module Dry
     extend ClassContext
 
     Result = Dry::Monads::Result
-    Result::Mixin = Dry::Monads::Result::Mixin
     include Result::Mixin
 
     # Wraps block's return value in a {Dry::Operation::Result::Success}

--- a/lib/dry/operation/errors.rb
+++ b/lib/dry/operation/errors.rb
@@ -39,7 +39,7 @@ module Dry
       def initialize(result:)
         super <<~MSG
           Your step must return `Success(..)` or `Failure(..)`, \
-          from `Dry::Monads::Result`. Instead, it was `#{result.inspect}`.
+          from `Dry::Operation::Result`. Instead, it was `#{result.inspect}`.
         MSG
       end
     end

--- a/spec/unit/operation_spec.rb
+++ b/spec/unit/operation_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe Dry::Operation do
-  include Dry::Monads[:result]
+  include Dry::Operation::Result::Mixin
 
   describe "#steps" do
     it "wraps block's return value in a Success" do
@@ -40,7 +40,7 @@ RSpec.describe Dry::Operation do
 
     # Make sure we don't use pattern matching to extract the value, as that
     # would be a problem with a value that is an array. See
-    # https://https://github.com/dry-rb/dry-monads/issues/173
+    # https://github.com/dry-rb/dry-monads/issues/173
     it "is able to extract an array from a success result" do
       expect(
         described_class.new.step(Success([:foo]))
@@ -62,7 +62,7 @@ RSpec.describe Dry::Operation do
         .with_message(
           <<~MSG
             Your step must return `Success(..)` or `Failure(..)`, \
-            from `Dry::Monads::Result`. Instead, it was `123`.
+            from `Dry::Operation::Result`. Instead, it was `123`.
           MSG
         )
     end


### PR DESCRIPTION
## Overview
This change would completely abstract away the implementation detail of using dry-monads. Monads are often intimidating to Ruby programmers, so it'd be nice if we could hide it from them. Then we can position dry-operation as a thin API and "just pattern matching" on the result, instead of thinking they need to understand what a monad before using it.

My primary interest here is for Hanami 2.2 users, who will get dry-operation included in their apps. A reference here is from Evan Czaplicki's talk ["Let's be mainstream!"](https://youtu.be/oYk8CKH7OhE?feature=shared&t=1455) where he talks about avoiding using "monad" at all, which is what Elm does.

## Details
Instead of `Dry::Monads[:result]`, users will include `Dry::Operation::Result::Mixin`. Since we're just aliasing the constant, people _can_ include the result from Dry::Monads and it'll work as desired. This might be nice if people are including several monads.

We could change this to something like `Dry::Operation[:result]` if we want to extend this, but I just wanted to open this PR to get the conversation started.

## Tradeoff
This does add some indirection, since we're adding an alias. I think it's worth it since it lowers the bar to entry for new users of dry-monads, and it only adds a small amount of added complexity for people working on dry-operation.