### PR TITLE
feat: Add extension for ActiveRecord transactions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :test do
 end
 
 group :development, :test do
+  gem "activerecord"
   gem "rom-sql"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.4"
 end

--- a/lib/dry/operation/extensions/active_record.rb
+++ b/lib/dry/operation/extensions/active_record.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+begin
+  require "active_record"
+rescue LoadError
+  raise Dry::Operation::MissingDependencyError.new(gem: "activerecord", extension: "ActiveRecord")
+end
+
+module Dry
+  class Operation
+    module Extensions
+      # Add ActiveRecord transaction support to operations
+      #
+      # When this extension is included, you can use a `#transaction` method
+      # to wrap the desired steps in an ActiveRecord transaction. If any of the steps
+      # returns a `Dry::Monads::Result::Failure`, the transaction will be rolled
+      # back and, as usual, the rest of the flow will be skipped.
+      #
+      # ```ruby
+      # class MyOperation < Dry::Operation
+      #   include Dry::Operation::Extensions::ActiveRecord
+      #
+      #   def call(input)
+      #     attrs = step validate(input)
+      #     user = transaction do
+      #       new_user = step persist(attrs)
+      #       step assign_initial_role(new_user)
+      #       new_user
+      #     end
+      #     step notify(user)
+      #     user
+      #   end
+      #
+      #   # ...
+      # end
+      # ```
+      #
+      # By default, the `ActiveRecord::Base` class will be used to initiate the transaction.
+      # You can change this when including the extension:
+      #
+      # ```ruby
+      # include Dry::Operation::Extensions::ActiveRecord[User]
+      # ```
+      #
+      # Or you can change it at runtime:
+      #
+      # ```ruby
+      # user = transaction(user) do
+      #  # ...
+      # end
+      # ```
+      #
+      # This is useful when you use multiple databases with ActiveRecord.
+      #
+      # @see https://rom-rb.org
+      # @see https://guides.rubyonrails.org/active_record_multiple_databases.html
+      module ActiveRecord
+        DEFAULT_CONNECTION = ::ActiveRecord::Base
+
+        # @!method transaction(connection = DEFAULT_CONNECTION, &steps)
+        #  Wrap the given steps in a ActiveRecord transaction.
+        #
+        #  If any of the steps returns a `Dry::Monads::Result::Failure`, the
+        #  transaction will be rolled back and `:halt` will be thrown with the
+        #  failure as its value.
+        #
+        #  @yieldreturn [Object] the result of the block
+        #  @see Dry::Operation#steps
+
+        def self.included(klass)
+          klass.include(self[])
+        end
+
+        # Include the extension providing a custom class/object to initialize the transaction
+        #
+        # @param connection [ActiveRecord::Base, #transaction] the class/object to use
+        def self.[](connection = DEFAULT_CONNECTION)
+          Builder.new(connection)
+        end
+
+        # @api private
+        class Builder < Module
+          def initialize(connection)
+            super()
+            @connection = connection
+          end
+
+          def included(klass)
+            class_exec(@connection) do |default_connection|
+              klass.define_method(:transaction) do |connection = default_connection, &steps|
+                connection.transaction(requires_new: true) do
+                  intercepting_failure(-> { raise ::ActiveRecord::Rollback }, &steps)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/operation/extensions/active_record.rb
+++ b/lib/dry/operation/extensions/active_record.rb
@@ -71,19 +71,6 @@ module Dry
       module ActiveRecord
         DEFAULT_CONNECTION = ::ActiveRecord::Base
 
-        # @!method transaction(connection = DEFAULT_CONNECTION, **options, &steps)
-        #  Wrap the given steps in an ActiveRecord transaction.
-        #
-        #  If any of the steps returns a `Dry::Monads::Result::Failure`, the
-        #  transaction will be rolled back and `:halt` will be thrown with the
-        #  failure as its value.
-        #
-        #  @param connection [ActiveRecord::Base, #transaction] the class/object to use
-        #  @param options [Hash] additional options for the ActiveRecord transaction
-        #  @yieldreturn [Object] the result of the block
-        #  @see Dry::Operation#steps
-        #  @see https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/DatabaseStatements.html#method-i-transaction
-
         def self.included(klass)
           klass.include(self[])
         end
@@ -107,6 +94,18 @@ module Dry
 
           def included(klass)
             class_exec(@connection, @options) do |default_connection, options|
+              # @!method transaction(connection = ActiveRecord::Base, **options, &steps)
+              #   Wrap the given steps in an ActiveRecord transaction.
+              #
+              #   If any of the steps returns a `Dry::Monads::Result::Failure`, the
+              #   transaction will be rolled back and `:halt` will be thrown with the
+              #   failure as its value.
+              #
+              #   @param connection [#transaction] The class/object to use
+              #   @param options [Hash] Additional options for the ActiveRecord transaction
+              #   @yieldreturn [Object] the result of the block
+              #   @see Dry::Operation#steps
+              #   @see https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/DatabaseStatements.html#method-i-transaction
               klass.define_method(:transaction) do |connection = default_connection, **opts, &steps|
                 connection.transaction(**options.merge(opts)) do
                   intercepting_failure(-> { raise ::ActiveRecord::Rollback }, &steps)

--- a/lib/dry/operation/extensions/active_record.rb
+++ b/lib/dry/operation/extensions/active_record.rb
@@ -52,13 +52,13 @@ module Dry
       #
       # This is useful when you use multiple databases with ActiveRecord.
       #
-      # @see https://rom-rb.org
+      # @see https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html
       # @see https://guides.rubyonrails.org/active_record_multiple_databases.html
       module ActiveRecord
         DEFAULT_CONNECTION = ::ActiveRecord::Base
 
         # @!method transaction(connection = DEFAULT_CONNECTION, &steps)
-        #  Wrap the given steps in a ActiveRecord transaction.
+        #  Wrap the given steps in an ActiveRecord transaction.
         #
         #  If any of the steps returns a `Dry::Monads::Result::Failure`, the
         #  transaction will be rolled back and `:halt` will be thrown with the

--- a/lib/dry/operation/extensions/active_record.rb
+++ b/lib/dry/operation/extensions/active_record.rb
@@ -106,9 +106,9 @@ module Dry
           end
 
           def included(klass)
-            class_exec(@connection, @options) do |default_connection, default_options|
-              klass.define_method(:transaction) do |connection = default_connection, **options, &steps|
-                connection.transaction(**default_options.merge(options)) do
+            class_exec(@connection, @options) do |default_connection, options|
+              klass.define_method(:transaction) do |connection = default_connection, **opts, &steps|
+                connection.transaction(**options.merge(opts)) do
                   intercepting_failure(-> { raise ::ActiveRecord::Rollback }, &steps)
                 end
               end

--- a/spec/integration/extensions/active_record_spec.rb
+++ b/spec/integration/extensions/active_record_spec.rb
@@ -90,12 +90,10 @@ RSpec.describe Dry::Operation::Extensions::ActiveRecord do
       end
     end.new(model)
 
-    expect(
-      instance.()
-    ).to eql(Success(1))
+    expect(instance.()).to eql(Success(1))
   end
 
-  it "ensures new savepoints for nested transactions" do
+  it "accepts options for ActiveRecord transaction method" do
     instance = Class.new(base) do
       def initialize(model)
         @model = model
@@ -105,7 +103,7 @@ RSpec.describe Dry::Operation::Extensions::ActiveRecord do
       def call
         transaction do
           step create_record
-          transaction do
+          transaction(requires_new: true) do
             step failure
           end
         end

--- a/spec/integration/extensions/active_record_spec.rb
+++ b/spec/integration/extensions/active_record_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Dry::Operation::Extensions::ActiveRecord do
+  include Dry::Monads[:result]
+
+  let!(:model) do
+    Class.new(ActiveRecord::Base) do
+      self.table_name = :foo
+    end
+  end
+
+  before :all do
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+    ActiveRecord::Schema.define do
+      create_table :foo do |t|
+        t.string :bar
+      end
+    end
+  end
+
+  after :each do
+    model.delete_all
+  end
+
+  let(:base) do
+    Class.new(Dry::Operation) do
+      include Dry::Operation::Extensions::ActiveRecord
+    end
+  end
+
+  it "rolls transaction back on failure" do
+    instance = Class.new(base) do
+      def call
+        transaction do
+          step create_record
+          step failure
+        end
+      end
+
+      def create_record
+        Success(ActiveRecord::Base.descendants.first.create(bar: "bar"))
+      end
+
+      def failure
+        Failure(:failure)
+      end
+    end.new
+
+    instance.()
+    expect(model.count).to be(0)
+  end
+
+  it "acts transparently for the regular flow" do
+    instance = Class.new(base) do
+      def call
+        transaction do
+          step create_record
+          step count_records
+        end
+      end
+
+      def create_record
+        Success(ActiveRecord::Base.descendants.first.create(bar: "bar"))
+      end
+
+      def count_records
+        Success(ActiveRecord::Base.descendants.first.count)
+      end
+    end.new
+
+    expect(
+      instance.()
+    ).to eql(Success(1))
+  end
+
+  it "ensures new savepoints for nested transactions" do
+    instance = Class.new(base) do
+      def call
+        transaction do
+          step create_record
+          transaction do
+            step failure
+          end
+        end
+      end
+
+      def create_record
+        Success(ActiveRecord::Base.descendants.first.create(bar: "bar"))
+      end
+
+      def failure
+        ActiveRecord::Base.descendants.first.create(bar: "bar")
+        Failure(:failure)
+      end
+    end.new
+
+    instance.()
+    expect(model.count).to be(1)
+  end
+end

--- a/spec/unit/extensions/active_record_spec.rb
+++ b/spec/unit/extensions/active_record_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Dry::Operation::Extensions::ActiveRecord do
+  describe "#transaction" do
+    it "ensures sub-transaction for nested transaction" do
+      instance = Class.new.include(Dry::Operation::Extensions::ActiveRecord).new
+
+      expect(ActiveRecord::Base).to receive(:transaction).with(requires_new: true)
+      instance.transaction {}
+    end
+  end
+end

--- a/spec/unit/extensions/active_record_spec.rb
+++ b/spec/unit/extensions/active_record_spec.rb
@@ -4,11 +4,26 @@ require "spec_helper"
 
 RSpec.describe Dry::Operation::Extensions::ActiveRecord do
   describe "#transaction" do
-    it "ensures sub-transaction for nested transaction" do
+    it "forwards options to ActiveRecord transaction call" do
       instance = Class.new.include(Dry::Operation::Extensions::ActiveRecord).new
 
       expect(ActiveRecord::Base).to receive(:transaction).with(requires_new: true)
-      instance.transaction {}
+      instance.transaction(requires_new: true) {}
+    end
+
+    it "accepts custom initiator and options" do
+      instance = Class.new.include(Dry::Operation::Extensions::ActiveRecord).new
+      record = double(:transaction)
+
+      expect(record).to receive(:transaction)
+      instance.transaction(record) {}
+    end
+
+    it "merges options with default options" do
+      instance = Class.new.include(Dry::Operation::Extensions::ActiveRecord[requires_new: true]).new
+
+      expect(ActiveRecord::Base).to receive(:transaction).with(requires_new: true, isolation: :serializable)
+      instance.transaction(isolation: :serializable) {}
     end
   end
 end


### PR DESCRIPTION
## Overview
The conventions of this gem have been adopted in many Rails applications using dry-monad/Do-notation. Therefore, it's useful to have an extension for ActiveRecord.

## Details
This PR introduces a new extension to Dry::Operation that allows operations to be wrapped in ActiveRecord transactions. This is useful for ensuring atomicity of operations that involve multiple steps that need to be rolled back in case of failure. The extension provides a `transaction` method that can be used to wrap steps in a transaction. The transaction will be rolled back if any of the steps return a `Dry::Monads::Result::Failure`.

The extension also supports specifying a custom ActiveRecord class to initiate the transaction, which is useful when working with multiple databases.