### PR TITLE
fixes: Dry::Operation::MissingDependencyError when not using extensions

### DIFF
--- a/lib/dry/operation.rb
+++ b/lib/dry/operation.rb
@@ -130,7 +130,8 @@ module Dry
         loader.tag = "dry-operation"
         loader.push_dir root
         loader.ignore(
-          "#{root}/dry/operation/errors.rb"
+          "#{root}/dry/operation/errors.rb",
+          "#{root}/dry/operation/extensions/*.rb"
         )
         loader.inflector.inflect("rom" => "ROM")
       end


### PR DESCRIPTION
fixes https://github.com/dry-rb/dry-operation/issues/19