### PR TITLE
Remove upfront extension requires

### DIFF
--- a/lib/dry/operation.rb
+++ b/lib/dry/operation.rb
@@ -3,8 +3,6 @@
 require "zeitwerk"
 require "dry/monads"
 require "dry/operation/errors"
-require "dry/operation/extensions/active_record"
-require "dry/operation/extensions/rom"
 
 module Dry
   # DSL for chaining operations that can fail

--- a/lib/dry/operation/extensions/active_record.rb
+++ b/lib/dry/operation/extensions/active_record.rb
@@ -17,6 +17,8 @@ module Dry
       # back and, as usual, the rest of the flow will be skipped.
       #
       # ```ruby
+      # require "dry/operation/extensions/active_record"
+      #
       # class MyOperation < Dry::Operation
       #   include Dry::Operation::Extensions::ActiveRecord
       #

--- a/lib/dry/operation/extensions/rom.rb
+++ b/lib/dry/operation/extensions/rom.rb
@@ -20,6 +20,8 @@ module Dry
       # container via a `#rom` method.
       #
       # ```ruby
+      # require "dry/operation/extensions/rom"
+      #
       # class MyOperation < Dry::Operation
       #   include Dry::Operation::Extensions::ROM
       #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ end
 Bundler.require :tools
 
 require "dry/operation"
+require "dry/operation/extensions/active_record"
+require "dry/operation/extensions/rom"
 
 SPEC_ROOT = Pathname(__dir__).realpath.freeze
 


### PR DESCRIPTION
## Overview

This commit addresses an issue where we were requiring all extension files upfront, which could raise errors if the required gems were not present in the user's environment. To resolve this, we've removed the automatic requires for ActiveRecord and ROM extensions from lib/dry/operation.rb.

Instead, we've updated the documentation in both ActiveRecord and ROM extension files to include the necessary require statement in the example code. To ensure our tests continue to pass with these changes, we've also added the requires to the spec_helper file.

See report: https://github.com/dry-rb/dry-operation/commit/92cdde9a9fd04e87c4b5d6c070494f444f104139#commitcomment-146824502

<!-- Required. Why is this important/necessary and what is the overarching architecture. -->

## Screenshots/Screencasts
<!-- Optional. Provide supporting image/video. -->

## Details
<!-- Optional. List the key features/highlights as bullet points. -->
