### PR TITLE
Fix transaction extensions to handle failures correctly

### DIFF
--- a/lib/dry/operation.rb
+++ b/lib/dry/operation.rb
@@ -172,35 +172,36 @@ module Dry
 
     # Invokes a callable in case of block's failure
     #
-    # Throws `:halt` with a {Dry::Monads::Result::Failure} on failure.
-    #
     # This method is useful when you want to perform some side-effect when a
     # failure is encountered. It's meant to be used within the {#steps} block
     # commonly wrapping a sub-set of {#step} calls.
     #
-    # @param handler [#call] a callable that will be called when a failure is encountered
+    # @param handler [#call] a callable that will be called with the encountered failure
     # @yieldreturn [Object]
-    # @return [Object] the block's return value
+    # @return [Object] the block's return value when it's not a failure or the handler's
+    #   return value when the block returns a failure
     def intercepting_failure(handler, &block)
       output = catching_failure(&block)
 
       case output
       when Failure
-        handler.()
-        throw_failure(output)
+        handler.(output)
       else
         output
       end
+    end
+
+    # Throws `:halt` with a failure
+    #
+    # @param failure [Dry::Monads::Result::Failure]
+    def throw_failure(failure)
+      throw FAILURE_TAG, failure
     end
 
     private
 
     def catching_failure(&block)
       catch(FAILURE_TAG, &block)
-    end
-
-    def throw_failure(failure)
-      throw FAILURE_TAG, failure
     end
   end
 end

--- a/lib/dry/operation.rb
+++ b/lib/dry/operation.rb
@@ -176,11 +176,12 @@ module Dry
     # failure is encountered. It's meant to be used within the {#steps} block
     # commonly wrapping a sub-set of {#step} calls.
     #
-    # @param handler [#call] a callable that will be called with the encountered failure
+    # @param handler [#call] a callable that will be called with the encountered failure.
+    #   By default, it throws `FAILURE_TAG` with the failure.
     # @yieldreturn [Object]
     # @return [Object] the block's return value when it's not a failure or the handler's
     #   return value when the block returns a failure
-    def intercepting_failure(handler, &block)
+    def intercepting_failure(handler = method(:throw_failure), &block)
       output = catching_failure(&block)
 
       case output

--- a/lib/dry/operation/extensions/active_record.rb
+++ b/lib/dry/operation/extensions/active_record.rb
@@ -111,7 +111,7 @@ module Dry
               #   @see Dry::Operation#steps
               #   @see https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/DatabaseStatements.html#method-i-transaction
               klass.define_method(:transaction) do |connection = default_connection, **opts, &steps|
-                intercepting_failure(method(:throw_failure)) do
+                intercepting_failure do
                   result = nil
                   connection.transaction(**options.merge(opts)) do
                     intercepting_failure(->(failure) {

--- a/lib/dry/operation/extensions/rom.rb
+++ b/lib/dry/operation/extensions/rom.rb
@@ -103,10 +103,17 @@ module Dry
                   that returns the ROM container
                 MSG
 
-                rom.gateways[gateway].transaction do |t|
-                  intercepting_failure(-> { raise t.rollback! }) do
-                    steps.()
+                intercepting_failure(method(:throw_failure)) do
+                  result = nil
+                  rom.gateways[gateway].transaction do |t|
+                    intercepting_failure(->(failure) {
+                                           result = failure
+                                           t.rollback!
+                                         }) do
+                      result = steps.()
+                    end
                   end
+                  result
                 end
               end
             end

--- a/lib/dry/operation/extensions/rom.rb
+++ b/lib/dry/operation/extensions/rom.rb
@@ -103,7 +103,7 @@ module Dry
                   that returns the ROM container
                 MSG
 
-                intercepting_failure(method(:throw_failure)) do
+                intercepting_failure do
                   result = nil
                   rom.gateways[gateway].transaction do |t|
                     intercepting_failure(->(failure) {

--- a/spec/unit/extensions/active_record_spec.rb
+++ b/spec/unit/extensions/active_record_spec.rb
@@ -5,14 +5,14 @@ require "spec_helper"
 RSpec.describe Dry::Operation::Extensions::ActiveRecord do
   describe "#transaction" do
     it "forwards options to ActiveRecord transaction call" do
-      instance = Class.new.include(Dry::Operation::Extensions::ActiveRecord).new
+      instance = Class.new(Dry::Operation).include(Dry::Operation::Extensions::ActiveRecord).new
 
       expect(ActiveRecord::Base).to receive(:transaction).with(requires_new: true)
       instance.transaction(requires_new: true) {}
     end
 
     it "accepts custom initiator and options" do
-      instance = Class.new.include(Dry::Operation::Extensions::ActiveRecord).new
+      instance = Class.new(Dry::Operation).include(Dry::Operation::Extensions::ActiveRecord).new
       record = double(:transaction)
 
       expect(record).to receive(:transaction)
@@ -20,7 +20,7 @@ RSpec.describe Dry::Operation::Extensions::ActiveRecord do
     end
 
     it "merges options with default options" do
-      instance = Class.new.include(Dry::Operation::Extensions::ActiveRecord[requires_new: true]).new
+      instance = Class.new(Dry::Operation).include(Dry::Operation::Extensions::ActiveRecord[requires_new: true]).new
 
       expect(ActiveRecord::Base).to receive(:transaction).with(requires_new: true, isolation: :serializable)
       instance.transaction(isolation: :serializable) {}


### PR DESCRIPTION
## Overview

The `intercepting_failure` method was not handling the block's output correctly when it was a failure. It wasn't throwing `:halt` with the failure as the given handlers were raising and therefore the throwing part was never reached.

We modify the method to pass the failure to the handler and skip the throwing part, while extensions need to work in two phases:

1 - From within the transaction block, they intercept a failure a first time and assign it to a `result` variable available from the outer scope. After that, they raise to rollback the transaction but return the `result` variable after that.

2 - From outside the transaction block, they throw again the failure when the `result` is actually a failure.

We also make public the `throw_failure` method so that other extensions can create similar behavior.

We also add a warning in the ActiveRecord extension to make it clear that the `:requires_new` option is not yet supported for this approach. We should find a way to make it work in the future.

Closes #23

<!-- Required. Why is this important/necessary and what is the overarching architecture. -->

## Screenshots/Screencasts
<!-- Optional. Provide supporting image/video. -->

## Details
<!-- Optional. List the key features/highlights as bullet points. -->
