### PR TITLE
Prepare for v1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2"]
+        ruby: ["3.1", "3.2", "3.3"]
 
     steps:
       - name: Checkout
@@ -30,4 +30,3 @@ jobs:
         with:
           name: coverage
           path: coverage
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
-# Versions
+# dry-operation
 
-## 0.0.0 (?)
+Model your app’s business operations.
 
-* Pending...
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [1.0.0] - 2024-11-02
+
+### Added
+
+- Initial release (@waiting-for-dev)
+
+[v1.0.0]: https://github.com/dry-rb/dry-operation/releases/tag/v1.0.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2023 dry-rb team
+Copyright (c) 2015-2024 dry-rb team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!--- this file is synced from dry-rb/template-gem project -->
 [gem]: https://rubygems.org/gems/dry-operation
 [actions]: https://github.com/dry-rb/dry-operation/actions
 
@@ -10,13 +9,6 @@
 * [API documentation](http://rubydoc.info/gems/dry-operation)
 * [Forum](https://discourse.dry-rb.org)
 
-## Supported Ruby versions
-
-This library officially supports the following Ruby versions:
-
-* MRI `>= 3.0.0`
-* jruby `>= 9.4` (not tested on CI)
-
 ## License
 
-See `LICENSE` file.
+See [`LICENSE`](LICENSE).

--- a/dry-operation.gemspec
+++ b/dry-operation.gemspec
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.prepend(lib) unless $LOAD_PATH.include?(lib)
+require "dry/operation/version"
+
 Gem::Specification.new do |spec|
   spec.name = "dry-operation"
-  spec.version = "0.0.0"
+  spec.version = Dry::Operation::VERSION
   spec.authors = ["dry-rb team"]
   spec.email = ["gems@dry-rb.org"]
   spec.homepage = "https://dry-rb.org/gems/dry-operation"
@@ -18,7 +22,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/dry-rb/dry-operation"
   }
 
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
   spec.add_dependency "zeitwerk", "~> 2.6"
   spec.add_dependency "dry-monads", "~> 1.6"
 

--- a/lib/dry/operation/version.rb
+++ b/lib/dry/operation/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Dry
+  class Operation
+    VERSION = "1.0.0"
+  end
+end


### PR DESCRIPTION
Drop support for Ruby 3.0, add a VERSION file and constant and use from the gemspec, add a CHANGELOG.