### PR TITLE
Use latest sqlite3, fix tests with Active Record 8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,5 +29,5 @@ group :development, :test do
   gem "activerecord"
   gem "rom-sql"
   gem "sequel"
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3"
 end


### PR DESCRIPTION
For some reason this gem dependency was added with a now-old 1.x version constraint. Active Record in Rails 8 now depends on sqlite 2.x.