### PR TITLE
Use edge activerecord-jdbcsqlite3-adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,8 @@ group :development, :test do
   gem "sequel"
   gem "sqlite3", platform: :mri
   gem "jdbc-sqlite3", platform: :jruby
-  gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
+
+  # Until ActiveRecord JDBC adapters in version 80.x or 81.x are not release, we are using version from
+  # master, as lower versions are incompatible with JRuby 10.1.x, against which we are testing.
+  gem "activerecord-jdbcsqlite3-adapter", github: "jruby/activerecord-jdbc-adapter", platform: :jruby
 end


### PR DESCRIPTION
Released versions do not work with JRuby 10.1, against which we want to test very soon.