### PR TITLE
Allow `#step` to be given a name, surfaced to `#on_failure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Added
 
+- `#step` now accepts an optional step name as its first argument (e.g. `step :validate, validate(input)`). When given, the name is forwarded to `#on_failure` via a new `step_name:` kwarg if the step fails, so a single `on_failure` hook can branch on which step failed. (@timriley in #42)
+- `#on_failure` now supports `step_name:` and `method_name:` keyword arguments. Hooks can opt in to either or both — e.g. `def on_failure(failure, step_name:)`, `def on_failure(failure, method_name:)`, or `def on_failure(failure, step_name:, method_name:)`. The existing positional params signatures are unchanged: `def on_failure(failure)` and `def on_failure(failure, method_name)`. (@timriley in #42)
+
 ### Changed
+
+- `#steps` now dispatches to `#on_failure` itself, so users who use `skip_prepending` and call `steps do ... end` manually get the same `#on_failure` routing as the auto-prepended case. Previously `#on_failure` only fired via the prepender. (@timriley in #42)
+- The Validation extension forwards `:validation` via the `step_name:` kwarg to `#on_failure` when contract validation fails, so users can distinguish contract failures from other named steps. (@timriley in #42)
 
 ### Deprecated
 

--- a/dry-operation.gemspec
+++ b/dry-operation.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.3"
 
+  spec.add_runtime_dependency "dry-core", "~> 1.1"
   spec.add_runtime_dependency "dry-monads", "~> 1.6"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
   spec.add_development_dependency "bundler"

--- a/lib/dry/operation.rb
+++ b/lib/dry/operation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "zeitwerk"
+require "dry/core/constants"
 require "dry/monads"
 require "dry/operation/errors"
 
@@ -74,28 +75,38 @@ module Dry
   # As you can see, the aforementioned behavior allows you to write your flow
   # in a linear fashion. Failures are mostly handled locally by each individual
   # operation. However, you can also define a global failure handler by defining
-  # an `#on_failure` method. It will be called with the wrapped failure value
-  # and, in the case of accepting a second argument, the name of the method that
-  # defined the flow:
+  # an `#on_failure` method. It will always be called with the wrapped failure
+  # value as its first argument, and may optionally accept either a positional
+  # second argument (the prepended method name) or `step_name:` and/or
+  # `method_name:` keyword arguments:
   #
   # ```ruby
   # class MyOperation < Dry::Operation
   #   def call(input)
-  #     attrs = step validate(input)
-  #     user = step persist(attrs)
-  #     step notify(user)
+  #     attrs = step :validate, validate(input)
+  #     user = step :persist, persist(attrs)
+  #     step :notify, notify(user)
   #     user
   #   end
   #
-  #   def on_failure(user) # or def on_failure(failure_value, method_name)
-  #     log_failure(user)
+  #   def on_failure(failure_value, step_name:)
+  #     case step_name
+  #     when :validate then log_validation_failure(failure_value)
+  #     when :persist then log_persistence_failure(failure_value)
+  #     when :notify then log_notification_failure(failure_value)
+  #     end
   #   end
   # end
   # ```
   #
+  # Naming steps is optional. When {#step} is called with just a result,
+  # `step_name:` will be `nil`. The `method_name:` kwarg always reflects the
+  # prepended method name (`:call` by default).
+  #
   # You can opt out altogether of this behavior via {ClassContext#skip_prepending}. If so,
-  # you manually need to wrap your flow within the {#steps} method and manually
-  # handle global failures.
+  # you manually need to wrap your flow within the {#steps} method.
+  # `#on_failure` is still dispatched by `#steps` itself, so it works the same
+  # as in the prepended case:
   #
   # ```ruby
   # class MyOperation < Dry::Operation
@@ -103,16 +114,16 @@ module Dry
   #
   #   def call(input)
   #     steps do
-  #       attrs = step validate(input)
-  #       user = step persist(attrs)
-  #       step notify(user)
+  #       attrs = step :validate, validate(input)
+  #       user  = step :persist, persist(attrs)
+  #       step :notify, notify(user)
   #       user
-  #     end.tap do |result|
-  #       log_failure(result.failure) if result.failure?
   #     end
   #   end
   #
-  #   # ...
+  #   def on_failure(failure, step_name:)
+  #     log_failure(failure, step_name)
+  #   end
   # end
   # ```
   #
@@ -138,21 +149,54 @@ module Dry
     end
     loader.setup
 
+    # @api private
     FAILURE_TAG = :halt
-    private_constant :FAILURE_TAG
+
+    # @api private
+    Undefined = Dry::Core::Constants::Undefined
+
+    # Internal throw payload pairing a failure with the name of the step that
+    # produced it. Used so the step name can flow back to `#on_failure`.
+    #
+    # @api private
+    StepFailure = Data.define(:failure, :step_name)
 
     extend ClassContext
     include Dry::Monads::Result::Mixin
 
     # Wraps block's return value in a {Dry::Monads::Result::Success}
     #
-    # Catches `:halt` and returns it
+    # Catches `:halt`, unwraps any step name carried by the throw, and
+    # dispatches the failure (if any) to `#on_failure`.
     #
+    # The prepender passes its `__method__` as `method_name:` so it flows to
+    # `#on_failure`'s `method_name:` kwarg. Manual callers (e.g. with
+    # {ClassContext#skip_prepending}) can pass it themselves; otherwise the
+    # `method_name:` kwarg arrives as `nil`.
+    #
+    # @param method_name [Symbol, nil] surfaced to `#on_failure` via `method_name:` on failure
     # @yieldreturn [Object]
-    # @return [Dry::Monads::Result::Success]
+    # @return [Dry::Monads::Result::Success, Object] the wrapped block result, or
+    #   the unwrapped failure / direct-throw value
     # @see #step
-    def steps(&block)
-      catching_failure { Success(block.call) }
+    def steps(method_name: nil, &block)
+      output = catch(FAILURE_TAG) { Success(block.call) }
+
+      result, step_name =
+        if output.is_a?(StepFailure)
+          [output.failure, output.step_name]
+        else
+          [output, nil]
+        end
+
+      ClassContext::FailureHookDispatcher.call(
+        self,
+        method_name: method_name,
+        step_name: step_name,
+        result: result
+      )
+
+      result
     end
 
     # Unwraps a {Dry::Monads::Result::Success}
@@ -161,14 +205,37 @@ module Dry
     #
     # If the given result responds to `#to_result`, this will be called before processing.
     #
-    # @param result [Dry::Monads::Result, #to_result]
+    # Optionally accepts a step name as the first argument. When given, the name is
+    # forwarded to `#on_failure` via the `step_name:` kwarg if the step fails.
+    #
+    # ```ruby
+    # def call(input)
+    #   attrs = step :validate, validate(input)
+    #   user  = step :persist, persist(attrs)
+    #   step :notify, notify(user)
+    #   user
+    # end
+    # ```
+    #
+    # @overload step(result)
+    #   @param result [Dry::Monads::Result, #to_result]
+    # @overload step(name, result)
+    #   @param name [Symbol] identifier surfaced to `#on_failure` via `step_name:` on failure
+    #   @param result [Dry::Monads::Result, #to_result]
     # @return [Object] wrapped value
     # @see #steps
-    def step(result)
+    def step(name_or_result, result = Undefined)
+      if Undefined.equal?(result)
+        step_name = nil
+        result = name_or_result
+      else
+        step_name = name_or_result
+      end
+
       raise InvalidStepResultError.new(result: result) unless result.respond_to?(:to_result)
 
       result = result.to_result
-      result.value_or { throw_failure(result) }
+      result.value_or { throw_failure(result, step_name:) }
     end
 
     # Invokes a callable in case of block's failure
@@ -196,14 +263,16 @@ module Dry
     # Throws `:halt` with a failure
     #
     # @param failure [Dry::Monads::Result::Failure]
-    def throw_failure(failure)
-      throw FAILURE_TAG, failure
+    # @param step_name [Symbol, nil] surfaced to `#on_failure` if set
+    def throw_failure(failure, step_name: nil)
+      throw FAILURE_TAG, StepFailure.new(failure, step_name)
     end
 
     private
 
     def catching_failure(&block)
-      catch(FAILURE_TAG, &block)
+      output = catch(FAILURE_TAG, &block)
+      output.is_a?(StepFailure) ? output.failure : output
     end
   end
 end

--- a/lib/dry/operation/class_context/failure_hook_dispatcher.rb
+++ b/lib/dry/operation/class_context/failure_hook_dispatcher.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "dry/operation/errors"
+
+module Dry
+  class Operation
+    module ClassContext
+      # Dispatches a failure result to an operation instance's `#on_failure`
+      # hook, supporting several signatures:
+      #
+      #   def on_failure(failure)
+      #   def on_failure(failure, method_name)
+      #   def on_failure(failure, step_name:)
+      #   def on_failure(failure, method_name:)
+      #   def on_failure(failure, step_name:, method_name:)
+      #
+      # @api private
+      module FailureHookDispatcher
+        FAILURE_HOOK_METHOD_NAME = :on_failure
+
+        SUPPORTED_KWARGS = %i[step_name method_name].freeze
+        private_constant :SUPPORTED_KWARGS
+
+        class << self
+          def call(instance, method_name:, step_name:, result:)
+            return unless result.is_a?(Dry::Monads::Result::Failure)
+
+            hook = lookup_hook(instance)
+            return unless hook
+
+            invoke_hook(hook, failure: result.failure, step_name: step_name, method_name: method_name)
+          end
+
+          private
+
+          def lookup_hook(instance)
+            return unless (instance.methods + instance.private_methods).include?(FAILURE_HOOK_METHOD_NAME)
+
+            instance.method(FAILURE_HOOK_METHOD_NAME)
+          end
+
+          # Dispatches to the hook based on its positional params arity.
+          #
+          # - Arity of 1: modern form. The hook receives `failure`, plus whichever of `step_name:`
+          #   and `method_name:` is explicitly accepted. When it accepts neither, the slice is
+          #   empty and `**{}` makes this equivalent to a plain `hook.(failure)` call.
+          # - Arity of 2: legacy form. The second positional is always `method_name`. Reject any
+          #   kwargs here, because mixing the two styles would be ambiguous about which identifier
+          #   the second positional carries.
+          # - Any other arity is unsupported and rejected.
+          def invoke_hook(hook, failure:, step_name:, method_name:)
+            positional, accepted_kwargs = parse_signature(hook)
+
+            case positional
+            when 1
+              kwargs = {step_name:, method_name:}.slice(*accepted_kwargs)
+              hook.(failure, **kwargs)
+            when 2
+              raise FailureHookArityError.new(hook: hook) unless accepted_kwargs.empty?
+
+              hook.(failure, method_name)
+            else
+              raise FailureHookArityError.new(hook: hook)
+            end
+          end
+
+          # Returns [positional_count, kwargs_array] from the failure hook method's `parameters`.
+          def parse_signature(hook)
+            positional = 0
+            kwargs = []
+
+            hook.parameters.each do |type, name|
+              case type
+              when :req, :opt then positional += 1
+              when :key, :keyreq then kwargs << name
+              else raise FailureHookArityError.new(hook: hook)
+              end
+            end
+
+            raise FailureHookArityError.new(hook: hook) if (kwargs - SUPPORTED_KWARGS).any?
+
+            [positional, kwargs]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/operation/class_context/steps_method_prepender.rb
+++ b/lib/dry/operation/class_context/steps_method_prepender.rb
@@ -1,35 +1,13 @@
 # frozen_string_literal: true
 
-require "dry/operation/errors"
-
 module Dry
   class Operation
     module ClassContext
       # @api private
       class StepsMethodPrepender < Module
-        FAILURE_HOOK_METHOD_NAME = :on_failure
-
-        RESULT_HANDLER = lambda do |instance, method, result|
-          return if result.success? ||
-                    !(instance.methods + instance.private_methods).include?(
-                      FAILURE_HOOK_METHOD_NAME
-                    )
-
-          failure_hook = instance.method(FAILURE_HOOK_METHOD_NAME)
-          case failure_hook.arity
-          when 1
-            failure_hook.(result.failure)
-          when 2
-            failure_hook.(result.failure, method)
-          else
-            raise FailureHookArityError.new(hook: failure_hook)
-          end
-        end
-
-        def initialize(method:, result_handler: RESULT_HANDLER)
+        def initialize(method:)
           super()
           @method = method
-          @result_handler = result_handler
         end
 
         def included(klass)
@@ -40,13 +18,9 @@ module Dry
 
         def mod
           @module ||= Module.new.tap do |mod|
-            module_exec(@result_handler) do |result_handler|
-              mod.define_method(@method) do |*args, **kwargs, &block|
-                steps do
-                  super(*args, **kwargs, &block)
-                end.tap do |result|
-                  result_handler.(self, __method__, result)
-                end
+            mod.define_method(@method) do |*args, **kwargs, &block|
+              steps(method_name: __method__) do
+                super(*args, **kwargs, &block)
               end
             end
           end

--- a/lib/dry/operation/errors.rb
+++ b/lib/dry/operation/errors.rb
@@ -46,12 +46,17 @@ module Dry
     # An error related to an extension
     class ExtensionError < ::StandardError; end
 
-    # Defined failure hook has wrong arity
+    # Defined failure hook has an unsupported signature
     class FailureHookArityError < ::StandardError
       def initialize(hook:)
         super <<~MSG
-          ##{hook.name} must accept 1 (failure) or 2 (failure, method name) \
-          arguments, but its arity is #{hook.arity}
+          ##{hook.name} must accept one of the following signatures:
+            (failure)
+            (failure, method_name)
+            (failure, step_name:)
+            (failure, method_name:)
+            (failure, step_name:, method_name:)
+          Its arity is #{hook.arity}.
         MSG
       end
     end

--- a/lib/dry/operation/extensions/validation.rb
+++ b/lib/dry/operation/extensions/validation.rb
@@ -15,6 +15,10 @@ module Dry
       # `params`, `schema`, or `contract`, or make a `#contract` dependency available from your
       # operation instance.
       #
+      # When validation fails, `#on_failure` receives `:validation` via the
+      # `step_name:` kwarg (if accepted), distinguishing contract failures from any
+      # other named steps in the flow.
+      #
       # @see https://dry-rb.org/gems/dry-validation/
       #
       # @api public
@@ -199,7 +203,7 @@ module Dry
                   super(validated_input, *rest, **kwargs, &block)
                 end
               when Dry::Monads::Failure
-                throw_failure(validation_result)
+                throw_failure(validation_result, step_name: :validation)
               end
             end
           end

--- a/repo-sync.yml
+++ b/repo-sync.yml
@@ -12,5 +12,6 @@ gemspec:
     - rspec
     - yard
   runtime_dependencies:
+    - [dry-core, "~> 1.1"]
     - [dry-monads, "~> 1.6"]
     - [zeitwerk, "~> 2.6"]

--- a/spec/integration/extensions/validation_spec.rb
+++ b/spec/integration/extensions/validation_spec.rb
@@ -73,6 +73,30 @@ RSpec.describe Dry::Operation::Extensions::Validation do
       expect(executed_steps).to be_empty
     end
 
+    it "passes :validation via the step_name: kwarg to #on_failure" do
+      received = nil
+
+      create_user = Class.new(Dry::Operation) do
+        include Dry::Operation::Extensions::Validation
+
+        params do
+          required(:name).filled(:string)
+        end
+
+        def call(input)
+          Success(input)
+        end
+
+        define_method(:on_failure) do |_failure, step_name:|
+          received = step_name
+        end
+      end
+
+      create_user.new.call(name: "")
+
+      expect(received).to be(:validation)
+    end
+
     it "coerces input values according to params schema" do
       calculate = Class.new(Dry::Operation) do
         include Dry::Operation::Extensions::Validation

--- a/spec/integration/operations_spec.rb
+++ b/spec/integration/operations_spec.rb
@@ -155,7 +155,121 @@ RSpec.describe "Operations" do
       ).to be(:call)
     end
 
-    it "has its arity checked and a meaningful error is raised when not conforming" do
+    it "is given the step name via the step_name: kwarg" do
+      klass = Class.new(Dry::Operation) do
+        attr_reader :received
+
+        def initialize
+          super
+          @received = nil
+        end
+
+        def call(x)
+          step :validate, validate(x)
+          step :persist, persist(x)
+        end
+
+        def validate(_x) = Success(:ok)
+        def persist(_x) = Failure(:db_error)
+
+        def on_failure(_failure, step_name:)
+          @received = step_name
+        end
+      end
+      instance = klass.new
+
+      instance.(1)
+
+      expect(
+        instance.received
+      ).to be(:persist)
+    end
+
+    it "passes nil for step_name: when an unnamed step fails" do
+      klass = Class.new(Dry::Operation) do
+        attr_reader :received
+
+        def initialize
+          super
+          @received = nil
+        end
+
+        def call(x)
+          step persist(x)
+        end
+
+        def persist(_x) = Failure(:db_error)
+
+        def on_failure(_failure, step_name:)
+          @received = step_name
+        end
+      end
+      instance = klass.new
+
+      instance.(1)
+
+      expect(
+        instance.received
+      ).to be_nil
+    end
+
+    it "is given the prepended method name via the method_name: kwarg" do
+      klass = Class.new(Dry::Operation) do
+        attr_reader :received
+
+        def initialize
+          super
+          @received = nil
+        end
+
+        def call(x)
+          step :persist, persist(x)
+        end
+
+        def persist(_x) = Failure(:db_error)
+
+        def on_failure(_failure, method_name:)
+          @received = method_name
+        end
+      end
+      instance = klass.new
+
+      instance.(1)
+
+      expect(
+        instance.received
+      ).to be(:call)
+    end
+
+    it "is given both names when both kwargs are accepted" do
+      klass = Class.new(Dry::Operation) do
+        attr_reader :received
+
+        def initialize
+          super
+          @received = nil
+        end
+
+        def call(x)
+          step :persist, persist(x)
+        end
+
+        def persist(_x) = Failure(:db_error)
+
+        def on_failure(_failure, step_name:, method_name:)
+          @received = {step_name: step_name, method_name: method_name}
+        end
+      end
+      instance = klass.new
+
+      instance.(1)
+
+      expect(
+        instance.received
+      ).to eq(step_name: :persist, method_name: :call)
+    end
+
+    it "raises a meaningful error when its signature is not supported" do
       klass = Class.new(Dry::Operation) do
         def call(x)
           step divide_by_zero(x)
@@ -167,6 +281,34 @@ RSpec.describe "Operations" do
       end
 
       expect { klass.new.(1) }.to raise_error(Dry::Operation::FailureHookArityError, /arity is 3/)
+    end
+
+    it "raises an error when arity-2 positional is mixed with kwargs" do
+      klass = Class.new(Dry::Operation) do
+        def call(x)
+          step divide_by_zero(x)
+        end
+
+        def divide_by_zero(_x) = Failure(:not_possible)
+
+        def on_failure(_failure, _name, step_name:); end
+      end
+
+      expect { klass.new.(1) }.to raise_error(Dry::Operation::FailureHookArityError)
+    end
+
+    it "raises an error for unrecognised kwargs" do
+      klass = Class.new(Dry::Operation) do
+        def call(x)
+          step divide_by_zero(x)
+        end
+
+        def divide_by_zero(_x) = Failure(:not_possible)
+
+        def on_failure(_failure, what:); end
+      end
+
+      expect { klass.new.(1) }.to raise_error(Dry::Operation::FailureHookArityError)
     end
 
     it "can be defined in a parent class" do
@@ -429,6 +571,30 @@ RSpec.describe "Operations" do
       expect(
         klass.new.(1)
       ).to eq(Success(2))
+    end
+
+    it "still dispatches to #on_failure from inside a manual #steps block" do
+      received = nil
+
+      klass = Class.new(Dry::Operation) do
+        skip_prepending
+
+        def call(x)
+          steps do
+            step :persist, persist(x)
+          end
+        end
+
+        def persist(_x) = Failure(:db_error)
+
+        define_method(:on_failure) do |_failure, step_name:|
+          received = step_name
+        end
+      end
+
+      klass.new.(1)
+
+      expect(received).to be(:persist)
     end
   end
 end

--- a/spec/unit/operation_spec.rb
+++ b/spec/unit/operation_spec.rb
@@ -47,12 +47,18 @@ RSpec.describe Dry::Operation do
       ).to eq([:foo])
     end
 
-    it "throws :halt with the result when given a failure" do
-      failure = Failure(:foo)
-
+    it "throws :halt when given a failure" do
       expect {
-        described_class.new.step(failure)
-      }.to throw_symbol(:halt, failure)
+        described_class.new.step(Failure(:foo))
+      }.to throw_symbol(:halt)
+    end
+
+    it "accepts an optional step name as the first argument" do
+      instance = described_class.new
+
+      expect(
+        instance.step(:my_step, Success(:foo))
+      ).to be(:foo)
     end
 
     it "raises helpful error when returning something that is not a Result" do
@@ -83,9 +89,7 @@ RSpec.describe Dry::Operation do
         end
       end.new
 
-      failure = Failure(:error)
-
-      expect { described_class.new.step(convertable_failure) }.to throw_symbol(:halt, failure)
+      expect { described_class.new.step(convertable_failure) }.to throw_symbol(:halt)
     end
   end
 
@@ -118,12 +122,10 @@ RSpec.describe Dry::Operation do
   end
 
   describe "#throw_failure" do
-    it "throws :halt with the failure" do
-      failure = Failure(:foo)
-
+    it "throws :halt" do
       expect {
-        described_class.new.throw_failure(failure)
-      }.to throw_symbol(:halt, failure)
+        described_class.new.throw_failure(Failure(:foo))
+      }.to throw_symbol(:halt)
     end
   end
 end


### PR DESCRIPTION
Allow steps to be given an optional name, so that the `on_failure` hook can differentiate between steps.

Now you can define steps like this:

```ruby
class MyOperation < Dry::Operation
  def call(input)
    attrs = step :validate, validate(input)
    user = step :persist, persist(attrs)
    step :notify, notify(user)

    # Unnamed steps still work as always:
    #
    # attrs = step validate(input)
    # user = step persist(attrs)
    # step notify(user)
    
    user
  end
end
```

With this done, you can use a new form on `on_failure`, which now accepts `step_name:` and `method_name:` as optional keyword arguments:

```ruby
def on_failure(failure, step_name:)
  case step_name
  when :validate
    # ...
  when :persist
    # ...
  else
    # ...
  end


  # or even something so simple as:
  log(failure, step_name)
end
```

Knowing the step name inside `on_failure` makes it much easier to add step-specific failure handling, like we see above. You can supply one or both of `method_name:` and `step_name:` to this method — we do params introspection behind the scenes to figure out what to pass.

Existing `on_failure` params signatures work exactly as before:

```
on_failure(failure)
on_failure(failure, method_name)
```

I expect this may be just the first step (🥁) in use of step names. Down the track we might want to consider their usage in other areas. For example, a nicer DSL for per-step failure handlers, standard failure structures "tagged" with the step name prepended, per-step "recovery" flows, instrumentation hooks, etc.

For starters, though, we keep this simple and focused on improving the facilities we already have.

To this end, while we're here, enhance the validation plugins so that it provides a `:validation` step name when validation fails.

### Implementation notes

- We pass the step name through to `on_failure` via the `throw` payload, which now becomes a `StepFailure` data class, holding both the failure and the step name.
- Our `steps` block API (in part an internal concern, but also a piece of lower-level public API) now invokes `on_failure` when a failure is encountered. This closes a gap in its earlier functionality, and allows us to continue using it from within `ClassContext::StepsMethodPrepender`.
- Calling `on_failure` has now become more complex with our params introspection, so that logic is now moved to a separate `ClassContext::FailureHookDispatcher` module.