### PR TITLE
Pin activerecord-jdbc-adapter to dodge broken AR 8.1 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,14 @@ group :development, :test do
   gem "sqlite3", platform: :mri
   gem "jdbc-sqlite3", platform: :jruby
 
-  # Until ActiveRecord JDBC adapters in version 80.x or 81.x are not release, we are using version from
-  # master, as lower versions are incompatible with JRuby 10.1.x, against which we are testing.
-  gem "activerecord-jdbcsqlite3-adapter", github: "jruby/activerecord-jdbc-adapter", platform: :jruby
+  # We track master because no released version of the adapter (80.x or 81.x) works yet with JRuby
+  # 10.1.x, which is what we test against.
+  #
+  # As of 2026-06-07, pin to a commit before jruby/activerecord-jdbc-adapter#1207, which relaxed the
+  # activerecord dependency to `~> 8.0` and pulls in activerecord 8.1.x. The adapter's 8.1 support
+  # is currently broken for SQLite3 (NoMethodError: undefined method 'mutable?' for nil).
+  gem "activerecord-jdbcsqlite3-adapter",
+    github: "jruby/activerecord-jdbc-adapter",
+    ref: "74aeab07a97001de74591ff5f50a6ff9807e9faa",
+    platform: :jruby
 end


### PR DESCRIPTION
We’re tracking this adapter from main, because no released version works with JRuby 10.1.x yet. On 2026-06-03, jruby/activerecord-jdbc-adapter#1207 relaxed its activerecord dependency from `~> 8.0.0` to `~> 8.0`, so CI started resolving activerecord 8.1.3. The adapter's SQLite3 support for 8.1 is broken, failing the ActiveRecord extension specs on JRuby with:

```
NoMethodError:
  undefined method 'mutable?' for nil
# ./vendor/bundle/jruby/4.0.0/gems/activerecord-8.1.3/lib/active_record/connection_adapters/column.rb:25:in 'initialize'
# ./vendor/bundle/jruby/4.0.0/bundler/gems/activerecord-jdbc-adapter-424d66984519/lib/arjdbc/sqlite3/column.rb:9:in 'initialize'
# ./vendor/bundle/jruby/4.0.0/gems/activerecord-8.1.3/lib/active_record/connection_adapters/deduplicable.rb:14:in 'new'
# ./vendor/bundle/jruby/4.0.0/bundler/gems/activerecord-jdbc-adapter-424d66984519/lib/arjdbc/sqlite3/adapter.rb:474:in 'new_column_from_field'
```

To work around this for now, pin activerecord-jdbc-adapter to 74aeab07, the last commit before #1207, which keeps activerecord on 8.0.x. We can unpin once the adapter's 8.1 SQLite3 support is fixed.