### PR TITLE
Require dry-monads 1.10.0 or later

### DIFF
--- a/dry-operation.gemspec
+++ b/dry-operation.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.3"
 
-  spec.add_runtime_dependency "dry-monads", "~> 1.6"
+  spec.add_runtime_dependency "dry-monads", "~> 1.10"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rspec"

--- a/repo-sync.yml
+++ b/repo-sync.yml
@@ -12,5 +12,5 @@ gemspec:
     - rspec
     - yard
   runtime_dependencies:
-    - [dry-monads, "~> 1.6"]
+    - [dry-monads, "~> 1.10"]
     - [zeitwerk, "~> 2.6"]


### PR DESCRIPTION
This ensures dry-monads’ RSpec extension is available, which is important for ease of testing operations.

See https://github.com/hanami/hanami-rspec/pull/48. Resolves #44.